### PR TITLE
新增stdio通信适配桌面端

### DIFF
--- a/janim/__main__.py
+++ b/janim/__main__.py
@@ -89,11 +89,6 @@ def render_args(
         action='store_true',
         help=_('Hide subtitles')
     )
-    parser.add_argument(
-        '--external_typst',
-        action='store_true',
-        help=_('Use external Typst executable for compiling Typst documents')
-    )
 
 
 def run_parser(parser: ArgumentParser) -> None:
@@ -105,12 +100,12 @@ def run_parser(parser: ArgumentParser) -> None:
     parser.add_argument(
         '-i', '--interact',
         action='store_true',
-        help=_('Enable the network socket for interacting with VS Code')
+        help=_('Enable the network socket for interacting with vscode')
     )
     parser.add_argument(
-        '-w', '--watch',
+        '--stdio',
         action='store_true',
-        help=_('Watches the file and rebuild on changes')
+        help=_('Enable stdio mode for Electron IPC')
     )
     parser.set_defaults(func=run)
 
@@ -207,9 +202,7 @@ def examples_parser(parser: ArgumentParser) -> None:
     parser.set_defaults(config=None)
     parser.set_defaults(func=run)
     parser.set_defaults(hide_subtitles=False)
-    parser.set_defaults(external_typst=False)
     parser.set_defaults(interact=False)
-    parser.set_defaults(watch=False)
 
 
 def tool_parser(parser: ArgumentParser) -> None:

--- a/janim/cli.py
+++ b/janim/cli.py
@@ -21,7 +21,6 @@ def run(args: Namespace) -> None:
     module = get_module(args.filepath)
     if module is None:
         return
-    modify_typst_compile_flag(args)
     modify_cli_config(args)
 
     timelines = extract_timelines_from_module(args, module)
@@ -55,7 +54,7 @@ def run(args: Namespace) -> None:
         viewer = AnimViewer(built,
                             auto_play=auto_play,
                             interact=args.interact,
-                            watch=args.watch,
+                            stdio=args.stdio,
                             available_timeline_names=available_timeline_names)
         widgets.append(viewer)
         viewer.show()
@@ -74,7 +73,6 @@ def write(args: Namespace) -> None:
     module = get_module(args.filepath)
     if module is None:
         return
-    modify_typst_compile_flag(args)
     modify_cli_config(args)
 
     timelines = extract_timelines_from_module(args, module)
@@ -235,14 +233,6 @@ def tool(args: Namespace) -> None:
     log.info('======')
 
     app.exec()
-
-
-def modify_typst_compile_flag(args: Namespace) -> None:
-    '''
-    用于 CLI 的 ``--external-typst`` 参数
-    '''
-    from janim.utils.typst_compile import set_use_external_typst
-    set_use_external_typst(args.external_typst)
 
 
 def modify_cli_config(args: Namespace) -> None:

--- a/janim/gui/ipc.py
+++ b/janim/gui/ipc.py
@@ -1,0 +1,162 @@
+import json
+import sys
+import threading
+from typing import Callable, Optional
+
+from PySide6.QtCore import QByteArray, QObject, Signal
+from PySide6.QtNetwork import QHostAddress, QUdpSocket
+
+from janim.locale.i18n import get_local_strings
+from janim.logger import log
+
+_ = get_local_strings('anim_viewer')
+
+
+class IPCConnection(QObject):
+    """
+    通信策略基类
+    """
+    # 当收到合法的 Janim JSON 数据包 ({'janim': ...}) 时发出此信号
+    message_received = Signal(dict)
+
+    def __init__(self, parent: Optional[QObject] = None):
+        super().__init__(parent)
+
+    def send(self, data: dict) -> None:
+        """发送数据 (data 应为完整的 dict，包含 'janim' key)"""
+        raise NotImplementedError
+
+    def cleanup(self) -> None:
+        """清理资源 (停止线程/关闭Socket)"""
+        pass
+
+
+class StdioConnection(IPCConnection):
+    """
+    基于标准输入输出 (Stdio) 的通信实现
+    用于 Electron 集成
+    """
+    def __init__(self, parent: Optional[QObject] = None):
+        super().__init__(parent)
+        self._running = True
+        # 使用 daemon 线程，防止主程序退出时线程卡死
+        self._thread = threading.Thread(target=self._listen_loop, daemon=True)
+        self._thread.start()
+        log.info(_('Listening on stdio for IPC command...'))
+
+    def _listen_loop(self) -> None:
+        while self._running:
+            try:
+                # 阻塞读取 stdin，直到收到换行符
+                line = sys.stdin.readline()
+                if not line:  # EOF (通常意味着父进程 Electron 关闭了管道)
+                    break
+                # 解析并验证是否为 JSON
+                data = json.loads(line.strip())
+                if isinstance(data, dict):
+                    self.message_received.emit(data)
+            except json.JSONDecodeError:
+                pass  # 忽略非 JSON 的日志输出
+            except Exception:
+                break
+
+    def send(self, data: dict) -> None:
+        try:
+            # flush=True 至关重要，否则 Electron 可能无法及时收到数据
+            print(json.dumps(data), flush=True)
+        except Exception:
+            pass
+
+    def cleanup(self) -> None:
+        self._running = False
+
+
+class UdpConnection(IPCConnection):
+    """
+    基于 UDP 的通信实现
+    用于 VSCode 插件交互 (Legacy)
+    """
+    def __init__(self,
+                 search_port: int,
+                 file_path: str,
+                 window_title_callback: Optional[Callable[[str], None]] = None,
+                 parent: Optional[QObject] = None):
+        super().__init__(parent)
+
+        self.file_path = file_path
+        self.clients: set[tuple[QHostAddress, int]] = set()
+
+        # 1. 初始化 Socket
+        self.socket = QUdpSocket(self)
+        self.shared_socket = QUdpSocket(self)
+
+        # 2. 绑定发现端口 (Shared) - 用于插件发现此实例
+        if 1024 <= search_port <= 65535:
+            ret = self.shared_socket.bind(
+                QHostAddress.SpecialAddress.LocalHost,
+                search_port,
+                QUdpSocket.BindFlag.ShareAddress | QUdpSocket.BindFlag.ReuseAddressHint
+            )
+            if ret:
+                self.shared_socket.readyRead.connect(self.on_shared_ready_read)
+                log.info(_('Searching port has been opened at {port}').format(port=search_port))
+            else:
+                log.warning(_('Failed to open searching port at {port}').format(port=search_port))
+        else:
+            log.warning(_('Searching port {port} is invalid').format(port=search_port))
+
+        # 3. 绑定交互端口 (OS 自动分配空闲端口)
+        self.socket.bind()
+        self.socket.readyRead.connect(self.on_ready_read)
+
+        local_port = self.socket.localPort()
+        log.info(_('Interactive port has been opened at {port}').format(port=local_port))
+
+        # 回调通知主窗口修改标题 (显示端口号)
+        if window_title_callback:
+            window_title_callback(f" [{local_port}]")
+
+    def on_shared_ready_read(self) -> None:
+        """处理发现请求 (Find)"""
+        while self.shared_socket.hasPendingDatagrams():
+            datagram = self.shared_socket.receiveDatagram()
+            try:
+                data = json.loads(datagram.data().toStdString())
+                if data.get('janim', {}).get('type') == 'find':
+                    # 直接在这里回复 find_re
+                    self._reply_find(datagram.senderAddress(), datagram.senderPort())
+            except Exception:
+                pass
+
+    def _reply_find(self, address: QHostAddress, port: int) -> None:
+        msg = json.dumps({
+            'janim': {
+                'type': 'find_re',
+                'data': {
+                    'port': self.socket.localPort(),
+                    'file_path': self.file_path
+                }
+            }
+        })
+        self.socket.writeDatagram(QByteArray.fromStdString(msg), address, port)
+
+    def on_ready_read(self) -> None:
+        """处理交互指令"""
+        while self.socket.hasPendingDatagrams():
+            datagram = self.socket.receiveDatagram()
+            try:
+                tree = json.loads(datagram.data().toStdString())
+                janim_data = tree.get('janim', {})
+
+                # UDP 特有逻辑：注册客户端地址
+                if janim_data.get('type') == 'register_client':
+                    self.clients.add((datagram.senderAddress(), datagram.senderPort()))
+
+                self.message_received.emit(tree)
+            except Exception:
+                pass
+
+    def send(self, data: dict) -> None:
+        msg = QByteArray.fromStdString(json.dumps(data))
+        for client in self.clients:
+            self.socket.writeDatagram(msg, *client)


### PR DESCRIPTION
electron不需要udp通信 所以我新建了stdio通信,为了整齐在cli加入了--stdio参数,例如 janim run learn.py --stdio


控制打印样例
```
(.venv) PS A:\program\JAnim> janim run learn.py --stdio
[11:25:07] INFO     ======                                                                               cli.py:40
           INFO     构建 "HelloJAnimExample" 中                                                    timeline.py:200
Skipping corrupt font: C:\Windows\Fonts\PHOTSE__.TTF
Skipping corrupt font: C:\WINDOWS\Fonts\PHOTSE__.TTF
[11:25:08] INFO     构建 "HelloJAnimExample" 完成，耗时 1.49 s                                     timeline.py:229
           INFO     ======                                                                               cli.py:47
           INFO     构建窗口中                                                                           cli.py:48
           INFO     Listening on stdio for IPC command...                                                ipc.py:45
{"janim": {"type": "lineno", "data": 15}}
[11:25:09] INFO     构建完成，耗时 1.05 s                                                                cli.py:66
           INFO     ======                                                                               cli.py:67
{"janim": {"type": "lineno", "data": 16}}
{"janim": {"type": "lineno", "data": 21}}
{"janim": {"type": "close_event"}}
```

顺便在animview解耦一个类,





你可以通过这个命令打包为exe    pyinstaller janim.spec --noconfirm --clean,然后把文件夹放到electron项目工作区
这是配置文件可置于janim工作区下

打包exe默认位于dist\janim\janim.exe
运行命令dist\janim\janim.exe  run learn.py



```
//janim.spec
# -*- mode: python ; coding: utf-8 -*-
from PyInstaller.utils.hooks import collect_data_files, collect_submodules, collect_all

block_cipher = None

janim_datas = collect_data_files('janim', include_py_files=False)

janim_hiddenimports = collect_submodules('janim')

rich_datas, rich_binaries, rich_hiddenimports = collect_all('rich')

all_datas = janim_datas + rich_datas
all_binaries = rich_binaries
all_hiddenimports = janim_hiddenimports + rich_hiddenimports + [
    # 补充几个必须的底层库，防止静态分析漏掉
    'pyside6',
    'moderngl',
    'watchdog',
    'skia',
    'svgelements'
]

a = Analysis(
    ['janim/__main__.py'],  
    pathex=[],
    binaries=all_binaries,
    datas=all_datas,
    hiddenimports=all_hiddenimports,
    hookspath=[],
    hooksconfig={},
    runtime_hooks=[],
    # 排除一些不需要的重型库，减小体积
    excludes=['tkinter', 'matplotlib', 'notebook', 'scipy'],
    win_no_prefer_redirects=False,
    win_private_assemblies=False,
    cipher=block_cipher,
    noarchive=False,
)

pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)

exe = EXE(
    pyz,
    a.scripts,
    [],
    exclude_binaries=True,
    name='janim',
    debug=False,
    bootloader_ignore_signals=False,
    strip=False,
    upx=True,
    console=True,
    disable_windowed_traceback=False,
    argv_emulation=False,
    target_arch=None,
    codesign_identity=None,
    entitlements_file=None,
)

coll = COLLECT(
    exe,
    a.binaries,
    a.zipfiles,
    a.datas,
    strip=False,
    upx=True,
    upx_exclude=[],
    name='janim',
)
//janim.spec end
```
