### PR TITLE
refactor: `get_all_timelines_from_module`

### DIFF
--- a/janim/cli.py
+++ b/janim/cli.py
@@ -415,32 +415,12 @@ def get_lineno_key_function(module) -> Callable[[type], tuple[int, int]] | None:
     - 如果能找到 class 在 module 中所定义的行数，则返回 ``(0, 行数)``
     - 如果找不到，则返回 ``(1, 0)``
 
-    **具体说明：**
+    **特殊情况说明：**
 
     对于重新载入的 module，如果代码里删除了某个类的代码，这个类仍然会出现在 module 中，
     但此时无法在 module 源代码中找到这个类的定义，所以把找不到的类返回 ``(1, 0)``，这样依据这个进行排序就会将其排序到最后
 
-    **技术细节：**
-
-    在 JAnim 更早的版本中，使用的代码是
-
-    .. code-block:: python
-
-        def key(cls):
-            try:
-                return (0, inspect.getsourcelines(cls)[1])
-            except OSError:
-                return (1, 0)
-
-    ``inspect.getsourcelines`` 它也是使用 AST 解析源代码查找类的定义，但是它的缺点在于：
-
-    - 如果一个文件中定义了重名的类定义，它会将找到的第一个作为类所定义的行数；
-      但是从语义上来说，后面的类定义已经把前面的覆盖了，所以更合理的效果是返回最后一次定义的行数
-
-    - 每次查找都要重新解析一遍源代码的 AST，复杂度是指数级上升的
-      （文件中的 ``Timeline`` 越多，调用 ``getsourcelines`` 的次数也越多；同时源代码更长，AST 也更复杂）
-
-    所以对于现在实现的这个函数，对于重复出现的类定义，后出现的行数会覆盖之前记录的行数，并且全程只会解析一次 AST
+    更多技术细节请参阅 https://github.com/jkjkil4/JAnim/pull/36
     '''
     file = inspect.getfile(module)
     if not file:


### PR DESCRIPTION
## Description

`get_all_timelines_from_module` scans `module.__dict__` for Timeline classes defined within the module. Crucially, it sorts them by their definition line number in the source code to ensure a consistent order for user selection.

Prior to this modification, `sort` utilized the following implementation:

```py
def key(cls):
    try:
        return (0, inspect.getsourcelines(cls)[1])
    except OSError:
        return (1, 0)
```

`inspect.getsourcelines` also relies on AST parsing to locate class definitions, but it suffers from the following drawbacks:

- **Handling Redefinitions:** If a file contains multiple class definitions with the same name, it identifies the line number of the *first* occurrence.
  However, semantically, the later definition overrides the earlier one. Therefore, the more reasonable behavior is to return the line number of the *last* definition.

- **Performance Overhead:** It re-parses the source code AST for every single lookup, leading to exponentially increasing complexity.
  (The more `Timeline` classes present in a file, the more frequently `getsourcelines` is called; simultaneously, longer source code results in a more complex AST.)

With the current implementation, subsequent class definitions overwrite the line numbers recorded for previous ones, and the AST is parsed only once for the entire process.

## Performance Benchmark and Comparison

<details>
<summary>Click to expand full code</summary>

```py
import ast
import inspect
import linecache
from typing import Callable

from janim.anims.timeline import Timeline

type SortKey = Callable[[type], tuple[int, int]]


def get_all_timelines_from_module(module, lineno_key: SortKey) -> list[type[Timeline]]:
    classes = [
        value
        for value in module.__dict__.values()
        if (isinstance(value, type)
            and issubclass(value, Timeline)
            and value.__module__ == module.__name__                             # 定义于当前模块，排除了 import 导入的
            and not value.__name__.startswith('_')                              # 排除以下划线开头的
            and not getattr(value.construct, '__isabstractmethod__', False))    # construct 方法已被实现
    ]
    if len(classes) <= 1:
        return classes

    if lineno_key is not None:
        classes.sort(key=lineno_key)

    return classes


def key_legacy(cls):
    try:
        return (0, inspect.getsourcelines(cls)[1])
    except OSError:
        return (1, 0)


def get_lineno_key_function(module) -> SortKey | None:
    file = inspect.getfile(module)
    if not file:
        return None

    # 模仿 inspect.findsource 的做法
    lines = linecache.getlines(file, module.__dict__)
    if not lines:
        return None

    source = ''.join(lines)
    tree = ast.parse(source)

    collector = _ClassDefCollector()
    collector.visit(tree)

    defs = collector.defs

    def lineno_key(cls: type) -> tuple[int, int]:
        lineno = defs.get(cls.__name__, None)
        if lineno is None:
            return (1, 0)
        return (0, lineno)

    return lineno_key


class _ClassDefCollector(ast.NodeVisitor):
    def __init__(self):
        self.defs: dict[str, int] = {}

    def visit_ClassDef(self, node: ast.ClassDef):
        # 因为我们只关心最后一次定义的位置，所以直接赋值就行
        self.defs[node.name] = node.lineno
        # 由于只关心最顶层的 classdef，所以不需要 generic_visit


def get_all_timelines_from_module_legacy(module) -> list[type[Timeline]]:
    return get_all_timelines_from_module(module, key_legacy)


def get_all_timelines_from_module_ast(module) -> list[type[Timeline]]:
    lineno_key = get_lineno_key_function(module)
    return get_all_timelines_from_module(module, lineno_key)


def benchmark(iterations: int = 100):
    import time

    import janim.examples

    module = janim.examples
    methods = [
        ('legacy', lambda: get_all_timelines_from_module_legacy(module)),
        ('ast', lambda: get_all_timelines_from_module_ast(module)),
    ]

    print('--- Benchmarking class discovery methods ---')
    for name, func in methods:
        func()  # warmup
        start = time.perf_counter()
        for _ in range(iterations):
            func()
        elapsed = time.perf_counter() - start
        per_call_us = elapsed / iterations * 1e6
        names = [cls.__name__ for cls in func()]
        print(f'{name:8s}: {per_call_us:8.2f} µs/call')
        print(f'-> {names}')
    print()


def compare():
    import test_redefine
    module = test_redefine

    print('--- Comparing methods on module with redefined classes (A, B, C, A) ---')

    legacy_result = get_all_timelines_from_module_legacy(module)
    ast_result = get_all_timelines_from_module_ast(module)

    legacy_names = [cls.__name__ for cls in legacy_result]
    ast_names = [cls.__name__ for cls in ast_result]

    print(f'Legacy method: {legacy_names}')
    print(f'AST method:    {ast_names}')
    print()


if __name__ == '__main__':
    benchmark()
    compare()
```

and `test_redefine.py`:

```py
from janim.anims.timeline import Timeline


class A(Timeline):
    def construct(self):
        pass


class B(Timeline):
    def construct(self):
        pass


class C(Timeline):
    def construct(self):
        pass


class A(Timeline):
    def construct(self):
        pass
```

</details>

Output results:

```
--- Benchmarking class discovery methods ---
legacy  : 25014.01 µs/call
-> ['HelloJAnimExample', 'BasicAnimationExample', 'TextExample', 'TypstExample', 'TypstColorizeExample', 'AnimatingPiExample', 'NumberPlaneExample', 'UpdaterExample', 'ArrowPointingExample', 'CombineUpdatersExample', 'RotatingPieExample', 'MarkedItemExample', 'FrameEffectExample']
ast     :  1311.05 µs/call
-> ['HelloJAnimExample', 'BasicAnimationExample', 'TextExample', 'TypstExample', 'TypstColorizeExample', 'AnimatingPiExample', 'NumberPlaneExample', 'UpdaterExample', 'ArrowPointingExample', 'CombineUpdatersExample', 'RotatingPieExample', 'MarkedItemExample', 'FrameEffectExample']

--- Comparing methods on module with redefined classes (A, B, C, A) ---
Legacy method: ['A', 'B', 'C']
AST method:    ['B', 'C', 'A']
```