### PR TITLE
Use `slots=True` for some dataclasses

### DIFF
--- a/janim/anims/animation.py
+++ b/janim/anims/animation.py
@@ -184,7 +184,7 @@ class ItemAnimation(Animation):
         self.stack.append(self)
         self.schedule_show_and_hide(self.item, self.show_at_begin, self.hide_at_end)
 
-    @dataclass
+    @dataclass(slots=True)
     class ApplyParams:
         global_t: float
         anims: list[ItemAnimation]
@@ -216,7 +216,7 @@ class ApplyAligner(ItemAnimation):
         pass
 
 
-@dataclass
+@dataclass(slots=True)
 class TimeRange:
     """
     标识了从 ``at`` 开始，到 ``end`` 结束的时间区段

--- a/janim/anims/creation.py
+++ b/janim/anims/creation.py
@@ -185,7 +185,7 @@ class DrawBorderThenFill(DataUpdater):
         self.stroke_radius = stroke_radius
         self.stroke_color = stroke_color
 
-    @dataclass
+    @dataclass(slots=True)
     class ExtraData:
         outline: VItem
         zero_data: VItem | None

--- a/janim/anims/method_updater_meta.py
+++ b/janim/anims/method_updater_meta.py
@@ -4,7 +4,7 @@ from typing import Callable
 METHOD_UPDATER_KEY = '__methodupdater_meta'
 
 
-@dataclass
+@dataclass(slots=True)
 class MethodUpdaterInfo:
     updater: Callable
     grouply: bool

--- a/janim/anims/timeline.py
+++ b/janim/anims/timeline.py
@@ -103,7 +103,7 @@ class Timeline(metaclass=ABCMeta):
 
     # endregion
 
-    @dataclass
+    @dataclass(slots=True)
     class ScheduledTask:
         """
         另见 :meth:`~.Timeline.schedule`

--- a/janim/components/component.py
+++ b/janim/components/component.py
@@ -37,7 +37,7 @@ class _CmptMeta(type):
 
 
 class Component[ItemT](refresh.Refreshable, metaclass=_CmptMeta):
-    @dataclass
+    @dataclass(slots=True)
     class BindInfo:
         """
         对组件定义信息的封装

--- a/janim/items/item.py
+++ b/janim/items/item.py
@@ -72,7 +72,7 @@ class _ItemMeta(type):
 
         return super().__new__(cls, name, bases, attrdict)
 
-    @dataclass
+    @dataclass(slots=True)
     class _CmptInitData:
         info: CmptInfo[CmptInfo]
         decl_cls: type[Item]

--- a/janim/utils/data.py
+++ b/janim/utils/data.py
@@ -67,7 +67,7 @@ class Array:
         return self._data is other._data
 
 
-@dataclass
+@dataclass(slots=True)
 class AlignedData[T]:
     """
     数据对齐后的结构，用于 :meth:`~.Item.align_for_interpolate`

--- a/janim/utils/font/exception.py
+++ b/janim/utils/font/exception.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from janim.utils.font.variant import Style
 
 
-@dataclass
+@dataclass(slots=True)
 class FontException:
     family: str | None = None
     weight: int | None = None

--- a/janim/utils/refresh.py
+++ b/janim/utils/refresh.py
@@ -53,6 +53,8 @@ class Refreshable:
 
 
 class RefreshData:
+    slots = ('is_required', 'stored')
+
     def __init__(self):
         self.is_required = True
         self.stored: Any = None

--- a/janim/utils/signal.py
+++ b/janim/utils/signal.py
@@ -36,7 +36,7 @@ class _SelfSlotWithRecurse:
     recurse_down: bool
 
 
-@dataclass
+@dataclass(slots=True)
 class _RefreshSlot:
     obj: weakref.ReferenceType[refresh.Refreshable]
     func: Callable | str


### PR DESCRIPTION
Used the script below to investigate

```py
# flake8: noqa

# --------------------------

import dataclasses
# import atexit
from functools import partial

# 保存原 dataclass 函数
_orig_dataclass = dataclasses.dataclass

# 全局记录所有被 hack 的 dataclass
_hacked_dataclasses = []

def dataclass(cls=None, /, **kwargs):
    if cls is None:
        return partial(_dataclass, **kwargs)
    return _dataclass(cls, **kwargs)

def _dataclass(cls, /, **kwargs):
    if not cls.__module__.startswith('janim.'):
        return _orig_dataclass(cls, **kwargs)

    # 保存原 __post_init__（可能不存在）
    orig_post_init = getattr(cls, "__post_init__", None)

    # 新的 __post_init__
    def new_post_init(self, *a, **k):
        datacls._instance_count += 1
        if orig_post_init:
            orig_post_init(self, *a, **k)

    cls.__post_init__ = new_post_init

    datacls = _orig_dataclass(cls, **kwargs)  # 调用原 dataclass
    datacls._instance_count = 0  # 类变量计数

    # # 记录到全局列表
    _hacked_dataclasses.append(datacls)

    return datacls

# 程序退出时统一输出计数
def print_all_counts():
    # 按次数排序，剔除计数为 0 的
    for cls in sorted(_hacked_dataclasses, key=lambda c: c._instance_count, reverse=True):
        if cls._instance_count > 0:
            print(f"{cls.__name__} created {cls._instance_count} instance(s).")

# atexit.register(print_all_counts)

# 覆盖原 dataclass
dataclasses.dataclass = dataclass

# --------------------------

import janim.examples as examples
from janim.cli import get_all_timelines_from_module

for tlcls in get_all_timelines_from_module(examples):
    tlcls().build()

print_all_counts()
```

```
BindInfo created 46614 instance(s).
_RefreshSlot created 8230 instance(s).
AlignedData created 7613 instance(s).
TimeRange created 4439 instance(s).
ApplyParams created 2734 instance(s).
ScheduledTask created 2405 instance(s).
_CmptInitData created 469 instance(s).
ExtraData created 363 instance(s).
TimeOfCode created 63 instance(s).
UpdaterParams created 61 instance(s).
FontException created 32 instance(s).
GlyphData created 22 instance(s).
MethodUpdaterInfo created 17 instance(s).
_SelfSlotWithRecurse created 3 instance(s).
AdditionalRenderCallsCallback created 3 instance(s).
FontDatabase created 1 instance(s).
```

Also investigated

```py
# --------------------------

from janim.imports import *

print_all_counts()
```

```
_CmptInitData created 461 instance(s).
FontException created 32 instance(s).
MethodUpdaterInfo created 17 instance(s).
_SelfSlotWithRecurse created 3 instance(s).
```