### PR TITLE
Safer hardware acceleration

### DIFF
--- a/janim/render/writer.py
+++ b/janim/render/writer.py
@@ -306,7 +306,7 @@ class VideoWriter:
 
     @staticmethod
     def test_encoder_usability(ffmpeg_bin: str, potential: str) -> bool:
-        exitcode, _ = sp.getstatusoutput([
+        exitcode, _ = sp.getstatusoutput(" ".join([
             ffmpeg_bin,
             '-f', 'lavfi',
             '-i', 'nullsrc=s=640x480:d=0.1',
@@ -314,7 +314,7 @@ class VideoWriter:
             '-f', 'null',
             '-loglevel', 'error',
             '-'
-        ])
+        ]))
         return exitcode == 0
 
     @staticmethod
@@ -329,7 +329,7 @@ class VideoWriter:
         else:
             return [
                 '-c:v', encoder,
-                '-vf', 'vflip'
+                '-vf', 'vflip,format=nv12'
             ]
 
     @staticmethod

--- a/janim/render/writer.py
+++ b/janim/render/writer.py
@@ -3,10 +3,10 @@ import shutil
 import subprocess as sp
 import sys
 import time
-from glob import glob
 from contextlib import contextmanager
-from functools import partial
-from typing import Generator, List
+from functools import lru_cache, partial
+from glob import glob
+from typing import Generator
 
 import moderngl as mgl
 import OpenGL.GL as gl
@@ -216,8 +216,10 @@ class VideoWriter:
         self.final_file_path = file_path
         self.temp_file_path = stem + '_temp' + self.ext
 
+        ffmpeg_bin = self.built.cfg.ffmpeg_bin
+
         command = [
-            self.built.cfg.ffmpeg_bin,
+            ffmpeg_bin,
             '-y',   # overwrite output file if it exists
             '-f', 'rawvideo',
             '-s', f'{self.built.cfg.pixel_width}x{self.built.cfg.pixel_height}',  # size of one frame
@@ -226,122 +228,125 @@ class VideoWriter:
             '-i', '-',  # The input comes from a pipe
             '-an',  # Tells FFMPEG not to expect any audio
             '-loglevel', 'error',
+            *self.ext_specific_flags(ffmpeg_bin, self.ext, hwaccel),
+            self.temp_file_path,
         ]
 
-        if self.ext == '.mp4':
-            encoder = self.find_encoder(self.built.cfg.ffmpeg_bin, hwaccel)
-            command += [
-                '-pix_fmt', 'yuv420p',
-                '-vcodec', encoder,
-                *self.encoder_flags(encoder)
-            ]
-        else:
-            command.extend([ '-vf', 'vflip' ])
-
-            if self.ext == '.mov':
-                # This is if the background of the exported
-                # video should be transparent.
-                command += [
-                    '-vcodec', 'qtrle',
-                ]
-            elif self.ext == '.gif':
-                pass
-            else:
-                assert False
-
-        command += [self.temp_file_path]
         with self.handle_ffmpeg_not_found():
             self.writing_process = sp.Popen(command, stdin=sp.PIPE)
 
-    hwencoder_cache: str | None = None
-    hwencoder_device_cache: str | None = None
+    @staticmethod
+    def ext_specific_flags(ffmpeg_bin: str, ext: str, hwaccel: bool) -> list[str]:
+        """针对不同的格式产生不同的 FFMPEG 参数"""
+
+        if ext == '.mp4':
+            with VideoWriter.handle_ffmpeg_not_found():
+                encoder = VideoWriter.find_h264_encoder(ffmpeg_bin, hwaccel)
+                log.info(_('Using {encoder} for encoding').format(encoder=encoder))
+                return [
+                    '-pix_fmt', 'yuv420p',
+                    *VideoWriter.encoder_flags(encoder)
+                ]
+
+        if ext == '.mov':
+            return [
+                '-c:v', 'qtrle',
+                '-vf', 'vflip'
+            ]
+
+        if ext == '.gif':
+            return [
+                '-vf', 'vflip'
+            ]
+
+        assert False
 
     @staticmethod
+    @lru_cache
+    def find_h264_encoder(ffmpeg_bin: str, hwaccel: bool) -> str:
+        """查找编码器，若 ``hwaccel=True`` 则优先使用硬件编码器"""
+        if not hwaccel:
+            return 'libx264'
+
+        # Call ffmpeg to enumerate available encoders
+        output = sp.getoutput(f'{ffmpeg_bin} -hide_banner -encoders')
+
+        encoders = [
+            'h264_vaapi',
+            'h264_nvenc',
+            'h264_qsv',
+            'h264_amf',
+            'h264_videotoolbox',
+        ]
+        available = [e for e in encoders if e in output]
+
+        # Attempt to use the potential encoder to see if it actually works
+        usable = [
+            potential
+            for potential in available
+            if VideoWriter.test_encoder_usability(ffmpeg_bin, potential)
+        ]
+
+        if available:
+            log.info(
+                _('Hardware encoder probe results:')
+                + ' '
+                + ', '.join(
+                    f'{e}={"ok" if e in usable else "fail"}'
+                    for e in available
+                )
+            )
+
+        if usable:
+            return usable[0]
+
+        # Safe fallback for if none of the probed hardware encoders work
+        log.info(_('No hardware encoder found'))
+        return 'libx264'
+
+    @staticmethod
+    def test_encoder_usability(ffmpeg_bin: str, potential: str) -> bool:
+        exitcode, _ = sp.getstatusoutput([
+            ffmpeg_bin,
+            '-f', 'lavfi',
+            '-i', 'nullsrc=s=640x480:d=0.1',
+            *VideoWriter.encoder_flags(potential),
+            '-f', 'null',
+            '-loglevel', 'error',
+            '-'
+        ])
+        return exitcode == 0
+
+    @staticmethod
+    def encoder_flags(encoder: str) -> list[str]:
+        device = VideoWriter.find_encoder_device()
+        if encoder == 'h264_vaapi' and device is not None:
+            return [
+                '-c:v', encoder,
+                '-vf', 'vflip,format=nv12,hwupload',
+                '-vaapi_device', device,
+            ]
+        else:
+            return [
+                '-c:v', encoder,
+                '-vf', 'vflip'
+            ]
+
+    @staticmethod
+    @lru_cache(maxsize=1)
     def find_encoder_device() -> str | None:
         """Return the first working VA-API render node, or None."""
         # Only applies on linux; exit early on other platforms
         # `linux` and `linux2` are both possible values
-        if not sys.platform.startswith("linux"):
-            device = None
-        elif VideoWriter.hwencoder_device_cache is not None:
-            device = VideoWriter.hwencoder_device_cache
-        else:
-            device = None
+        if not sys.platform.startswith('linux'):
+            return None
 
-            # If `/dev/dri` doesn't exist, this will just return an empty array
-            for device_node in sorted(glob('/dev/dri/renderD*')):
-                if os.access(device_node, os.R_OK | os.W_OK):
-                    device = device_node
-                    VideoWriter.hwencoder_device_cache = device_node
+        # If `/dev/dri` doesn't exist, this will just return an empty array
+        for device_node in sorted(glob('/dev/dri/renderD*')):
+            if os.access(device_node, os.R_OK | os.W_OK):
+                return device_node
 
-        return device
-
-    @staticmethod
-    def encoder_flags(encoder: str) -> List[str]:
-        device = VideoWriter.find_encoder_device()
-        if encoder == "h264_vaapi" and device is not None:
-            return [
-                '-vaapi_device', device,
-                '-vf', 'vflip,format=nv12,hwupload'
-            ]
-        else:
-            return [ '-vf', 'vflip' ]
-
-    @staticmethod
-    def find_encoder(ffmpeg_bin: str, hwaccel: bool) -> str:
-        """查找编码器，若 ``hwaccel=True`` 则优先使用硬件编码器"""
-        if not hwaccel:
-            encoder = 'libx264'
-        else:
-            if VideoWriter.hwencoder_cache is not None:
-                encoder = VideoWriter.hwencoder_cache
-            else:
-                encoder = None
-                output = ""
-
-                # Call ffmpeg to enumerate available encoders
-                with VideoWriter.handle_ffmpeg_not_found():
-                    output = sp.getoutput(f"{ffmpeg_bin} -hide_banner -encoders")
-
-                encoders = [
-                    "h264_vaapi",
-                    "h264_nvenc",
-                    "h264_qsv",
-                    "h264_amf",
-                    "h264_videotoolbox",
-                ]
-                available = [e for e in encoders if e in output]
-
-                log.info(f"Encoders available to ffmpeg: {available}")
-
-                for potential in available:
-                    # Attempt to use the potential encoder to see if it actually works
-                    output, _ = sp.getstatusoutput(" ".join([
-                        ffmpeg_bin,
-                         "-f", "lavfi",
-                         "-i", "nullsrc=s=128x128",
-                         "-t", "1",
-                         "-c:v", potential,
-                         *VideoWriter.encoder_flags(potential),
-                         "-f", "null",
-                         os.devnull
-                    ]))
-
-                    # If the potential encoder succeeded
-                    if int(output) != 0:
-                       encoder = potential
-                    else:
-                        log.info(f"ffmpeg was packaged with the `{potential}` encoder but your system cannot utilize it.")
-
-                # Safe fallback for if none of the probed hardware encoders work
-                if encoder is None:
-                    encoder = 'libx264'
-                    log.info("No hardware encoder found")
-
-                VideoWriter.hwencoder_cache = encoder
-
-        log.info(f"Using {encoder} for encoding")
-        return encoder
+        return None
 
     def close_video_pipe(self, _keep_temp: bool) -> None:
         self.writing_process.stdin.close()

--- a/janim/render/writer.py
+++ b/janim/render/writer.py
@@ -1,8 +1,8 @@
-import glob
 import os
 import shutil
 import subprocess as sp
 import time
+import glob
 from contextlib import contextmanager
 from functools import partial
 from typing import Generator, List
@@ -290,25 +290,24 @@ class VideoWriter:
                 encoder = VideoWriter.hwencoder_cache
             else:
                 encoder = None
+                output = ""
 
                 # Call ffmpeg to enumerate available encoders
                 with VideoWriter.handle_ffmpeg_not_found():
-                    test_availability = sp.Popen(
-                        [ffmpeg_bin, '-hide_banner', '-encoders'],
-                        stdout=sp.PIPE,
-                        stderr=sp.PIPE
-                    )
+                    output = sp.getoutput(f"{ffmpeg_bin} -hide_banner -encoders")
 
-                out, err = test_availability.communicate()
+                log.info(f"{output}")
 
                 encoders = [
-                    'h264_vaapi'
-                    'h264_nvenc'
-                    'h264_qsv'
-                    'h264_amf'
+                    "h264_vaapi",
+                    "h264_nvenc",
+                    "h264_qsv",
+                    "h264_amf",
                 ]
-                available = [enc for enc in encoders if enc.encode() in out]
 
+                available = [e for e in encoders if e in output]
+
+                log.info(f"Encoders available to ffmpeg: {available}")
 
                 for potential in available:
                     # Attempt to use the potential encoder to see if it actually works
@@ -331,7 +330,7 @@ class VideoWriter:
                     if test_encoder.returncode == 0:
                        encoder = potential
                     else:
-                        log.info(_('ffmpeg was packaged with the \\`{potential}\\` encoder but your system cannot utilize it.').format(potential=potential))
+                        log.info(f"ffmpeg was packaged with the `{potential}` encoder but your system cannot utilize it.")
 
                 # Safe fallback for if none of the probed hardware encoders work
                 if encoder is None:
@@ -340,7 +339,7 @@ class VideoWriter:
 
                 VideoWriter.hwencoder_cache = encoder
 
-        log.info(_('Using {encoder} for encoding').format(encoder=encoder))
+        log.info(f"Using {encoder} for encoding")
         return encoder
 
     def close_video_pipe(self, _keep_temp: bool) -> None:

--- a/janim/render/writer.py
+++ b/janim/render/writer.py
@@ -260,7 +260,8 @@ class VideoWriter:
     def find_encoder_device() -> str | None:
         """Return the first working VA-API render node, or None."""
         # Only applies on linux; exit early on other platforms
-        if sys.platform != "linux":
+        # `linux` and `linux2` are both possible values
+        if not sys.platform.startswith("linux"):
             device = None
         if VideoWriter.hwencoder_device_cache is not None:
             device = VideoWriter.hwencoder_device_cache

--- a/janim/render/writer.py
+++ b/janim/render/writer.py
@@ -1,10 +1,11 @@
+import glob
 import os
 import shutil
 import subprocess as sp
 import time
 from contextlib import contextmanager
 from functools import partial
-from typing import Generator
+from typing import Generator, List
 
 import moderngl as mgl
 import OpenGL.GL as gl
@@ -222,32 +223,62 @@ class VideoWriter:
             '-pix_fmt', 'rgba',
             '-r', str(self.built.cfg.fps),  # frames per second
             '-i', '-',  # The input comes from a pipe
-            '-vf', 'vflip',
             '-an',  # Tells FFMPEG not to expect any audio
             '-loglevel', 'error',
         ]
 
         if self.ext == '.mp4':
+            encoder = self.find_encoder(self.built.cfg.ffmpeg_bin, hwaccel)
             command += [
                 '-pix_fmt', 'yuv420p',
-                '-vcodec', self.find_encoder(self.built.cfg.ffmpeg_bin, hwaccel),
+                '-vcodec', encoder,
+                *self.encoder_flags(encoder)
             ]
-        elif self.ext == '.mov':
-            # This is if the background of the exported
-            # video should be transparent.
-            command += [
-                '-vcodec', 'qtrle',
-            ]
-        elif self.ext == '.gif':
-            pass
         else:
-            assert False
+            command.extend([ '-vf', 'vflip' ])
+
+            if self.ext == '.mov':
+                # This is if the background of the exported
+                # video should be transparent.
+                command += [
+                    '-vcodec', 'qtrle',
+                ]
+            elif self.ext == '.gif':
+                pass
+            else:
+                assert False
 
         command += [self.temp_file_path]
         with self.handle_ffmpeg_not_found():
             self.writing_process = sp.Popen(command, stdin=sp.PIPE)
 
     hwencoder_cache: str | None = None
+    hwencoder_device_cache: str | None = None
+
+    @staticmethod
+    def find_encoder_device() -> str | None:
+        """Return the first working VA-API render node, or None."""
+        if VideoWriter.hwencoder_device_cache is not None:
+            device = VideoWriter.hwencoder_device_cache
+        else:
+            device = None
+            for device_node in sorted(glob.glob('/dev/dri/renderD*')):
+                if os.access(device_node, os.R_OK | os.W_OK):
+                    device = device_node
+                    VideoWriter.hwencoder_device_cache = device_node
+
+        return device
+
+    @staticmethod
+    def encoder_flags(encoder: str) -> List[str]:
+        device = VideoWriter.find_encoder_device()
+        if encoder == "h264_vaapi" and device is not None:
+            return [
+                '-vaapi_device', device,
+                '-vf', 'vflip,format=nv12,hwupload'
+            ]
+        else:
+            return [ '-vf', 'vflip' ]
 
     @staticmethod
     def find_encoder(ffmpeg_bin: str, hwaccel: bool) -> str:
@@ -258,7 +289,9 @@ class VideoWriter:
             if VideoWriter.hwencoder_cache is not None:
                 encoder = VideoWriter.hwencoder_cache
             else:
-                # call ffmpeg to test nvenc/amf support
+                encoder = None
+
+                # Call ffmpeg to enumerate available encoders
                 with VideoWriter.handle_ffmpeg_not_found():
                     test_availability = sp.Popen(
                         [ffmpeg_bin, '-hide_banner', '-encoders'],
@@ -267,13 +300,44 @@ class VideoWriter:
                     )
 
                 out, err = test_availability.communicate()
-                if b'h264_nvenc' in out:
-                    encoder = 'h264_nvenc'
-                elif b'h264_amf' in out:
-                    encoder = 'h264_amf'
-                else:
+
+                encoders = [
+                    'h264_vaapi'
+                    'h264_nvenc'
+                    'h264_qsv'
+                    'h264_amf'
+                ]
+                available = [enc for enc in encoders if enc.encode() in out]
+
+
+                for potential in available:
+                    # Attempt to use the potential encoder to see if it actually works
+                    test_encoder = sp.run(
+                        [
+                            ffmpeg_bin,
+                             "-f", "lavfi",
+                             "-i", "nullsrc=s=128x128",
+                             "-t", "1",
+                             "-c:v", potential,
+                             *VideoWriter.encoder_flags(potential),
+                             "-f", "null",
+                             "/dev/null"
+                        ],
+                        stdout=sp.DEVNULL,
+                        stderr=sp.DEVNULL
+                    )
+
+                    # If the potential encoder succeeded
+                    if test_encoder.returncode == 0:
+                       encoder = potential
+                    else:
+                        log.info(_('ffmpeg was packaged with the \\`{potential}\\` encoder but your system cannot utilize it.').format(potential=potential))
+
+                # Safe fallback for if none of the probed hardware encoders work
+                if encoder is None:
                     encoder = 'libx264'
                     log.info(_('No hardware encoder found'))
+
                 VideoWriter.hwencoder_cache = encoder
 
         log.info(_('Using {encoder} for encoding').format(encoder=encoder))

--- a/janim/render/writer.py
+++ b/janim/render/writer.py
@@ -263,7 +263,7 @@ class VideoWriter:
         # `linux` and `linux2` are both possible values
         if not sys.platform.startswith("linux"):
             device = None
-        if VideoWriter.hwencoder_device_cache is not None:
+        elif VideoWriter.hwencoder_device_cache is not None:
             device = VideoWriter.hwencoder_device_cache
         else:
             device = None

--- a/janim/render/writer.py
+++ b/janim/render/writer.py
@@ -3,7 +3,7 @@ import shutil
 import subprocess as sp
 import sys
 import time
-import glob
+from glob import glob
 from contextlib import contextmanager
 from functools import partial
 from typing import Generator, List
@@ -259,7 +259,7 @@ class VideoWriter:
     @staticmethod
     def find_encoder_device() -> str | None:
         """Return the first working VA-API render node, or None."""
-        # Only applies on linux
+        # Only applies on linux; exit early on other platforms
         if sys.platform != "linux":
             device = None
         if VideoWriter.hwencoder_device_cache is not None:
@@ -267,7 +267,8 @@ class VideoWriter:
         else:
             device = None
 
-            for device_node in sorted(glob.glob('/dev/dri/renderD*')):
+            # If `/dev/dri` doesn't exist, this will just return an empty array
+            for device_node in sorted(glob('/dev/dri/renderD*')):
                 if os.access(device_node, os.R_OK | os.W_OK):
                     device = device_node
                     VideoWriter.hwencoder_device_cache = device_node

--- a/janim/render/writer.py
+++ b/janim/render/writer.py
@@ -296,15 +296,12 @@ class VideoWriter:
                 with VideoWriter.handle_ffmpeg_not_found():
                     output = sp.getoutput(f"{ffmpeg_bin} -hide_banner -encoders")
 
-                log.info(f"{output}")
-
                 encoders = [
                     "h264_vaapi",
                     "h264_nvenc",
                     "h264_qsv",
                     "h264_amf",
                 ]
-
                 available = [e for e in encoders if e in output]
 
                 log.info(f"Encoders available to ffmpeg: {available}")

--- a/janim/render/writer.py
+++ b/janim/render/writer.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 import subprocess as sp
+import sys
 import time
 import glob
 from contextlib import contextmanager
@@ -258,10 +259,14 @@ class VideoWriter:
     @staticmethod
     def find_encoder_device() -> str | None:
         """Return the first working VA-API render node, or None."""
+        # Only applies on linux
+        if sys.platform != "linux":
+            device = None
         if VideoWriter.hwencoder_device_cache is not None:
             device = VideoWriter.hwencoder_device_cache
         else:
             device = None
+
             for device_node in sorted(glob.glob('/dev/dri/renderD*')):
                 if os.access(device_node, os.R_OK | os.W_OK):
                     device = device_node
@@ -301,6 +306,7 @@ class VideoWriter:
                     "h264_nvenc",
                     "h264_qsv",
                     "h264_amf",
+                    "h264_videotoolbox",
                 ]
                 available = [e for e in encoders if e in output]
 
@@ -308,23 +314,19 @@ class VideoWriter:
 
                 for potential in available:
                     # Attempt to use the potential encoder to see if it actually works
-                    test_encoder = sp.run(
-                        [
-                            ffmpeg_bin,
-                             "-f", "lavfi",
-                             "-i", "nullsrc=s=128x128",
-                             "-t", "1",
-                             "-c:v", potential,
-                             *VideoWriter.encoder_flags(potential),
-                             "-f", "null",
-                             "/dev/null"
-                        ],
-                        stdout=sp.DEVNULL,
-                        stderr=sp.DEVNULL
-                    )
+                    output, _ = sp.getstatusoutput(" ".join([
+                        ffmpeg_bin,
+                         "-f", "lavfi",
+                         "-i", "nullsrc=s=128x128",
+                         "-t", "1",
+                         "-c:v", potential,
+                         *VideoWriter.encoder_flags(potential),
+                         "-f", "null",
+                         os.devnull
+                    ]))
 
                     # If the potential encoder succeeded
-                    if test_encoder.returncode == 0:
+                    if int(output) != 0:
                        encoder = potential
                     else:
                         log.info(f"ffmpeg was packaged with the `{potential}` encoder but your system cannot utilize it.")
@@ -332,7 +334,7 @@ class VideoWriter:
                 # Safe fallback for if none of the probed hardware encoders work
                 if encoder is None:
                     encoder = 'libx264'
-                    log.info(_('No hardware encoder found'))
+                    log.info("No hardware encoder found")
 
                 VideoWriter.hwencoder_cache = encoder
 


### PR DESCRIPTION
In the current version of JAnim , my desktop computer cannot render output.
The computer does not have hardware acceleration available to it, but that shouldn't matter, it should safely fall back to `libx264`. 

Currently, the logic in `writer.py` assumes that if the encoder is listed in the `ffmpeg -encoders` output, that this means that encoder is hardware-compatible. That isn't the case- lots of people (myself included) end up using versions of `ffmpeg` that are built / packaged with more support for hardware acceleration than their systems actually have in terms of physical graphics cards and/or drivers. 

Therefore, I've adjusted the file in question. Now, it will check which encoders are available to `ffmpeg`, and then actually test that they work using a `nullsrc` render job. If the job succeeds, we know that we can actually use the encoder.

The changes here also add support for `vaapi` and `qsv` h264 encoding. 

here's some output from my machine:
```
INFO     Encoders available to ffmpeg: ['h264_vaapi', 'h264_nvenc', 'h264_qsv', 'h264_amf']
INFO     ffmpeg was packaged with the `h264_vaapi` encoder but your system cannot utilize it.
INFO     ffmpeg was packaged with the `h264_nvenc` encoder but your system cannot utilize it.
INFO     ffmpeg was packaged with the `h264_qsv` encoder but your system cannot utilize it.
INFO     ffmpeg was packaged with the `h264_amf` encoder but your system cannot utilize it.
INFO     No hardware encoder found
INFO     Using libx264 for encoding
```

this change would improve linux compatibility both for those with hardware acceleration and for those without it.
thank you!